### PR TITLE
adds a faster alternative of InvokeNamed

### DIFF
--- a/R.NET/Function.cs
+++ b/R.NET/Function.cs
@@ -125,5 +125,30 @@ namespace RDotNet
               }
           }
       }
+
+      /// <summary>
+      /// Invoke the function with optionally named arguments by order.
+      /// </summary>
+      /// <param name="args">one or more tuples, conceptually a pairlist of arguments.
+      /// The argument names must be unique; null or empty string indicates unnamed argument. </param>
+      /// <returns>The result of the function evaluation</returns>
+      public SymbolicExpression InvokeNamedFast(params Tuple<string, SymbolicExpression>[] args)
+      {
+          IntPtr argument = Engine.NilValue.DangerousGetHandle();
+          var rfInstall = GetFunction<Rf_install>();
+          var rSetTag = GetFunction<R_SetExternalPtrTag>();
+          var rfCons = GetFunction<Rf_cons>();
+          foreach (var arg in args.Reverse())
+          {
+              var sexp = arg.Item2;
+              argument = rfCons(sexp.DangerousGetHandle(), argument);
+              string name = arg.Item1;
+              if (!string.IsNullOrEmpty(name))
+              {
+                  rSetTag(argument, rfInstall(name));
+              }
+          }
+          return createCallAndEvaluate(argument);
+      }
    }
 }

--- a/R.NET/Function.cs
+++ b/R.NET/Function.cs
@@ -136,7 +136,7 @@ namespace RDotNet
       {
           IntPtr argument = Engine.NilValue.DangerousGetHandle();
           var rfInstall = GetFunction<Rf_install>();
-          var rSetTag = GetFunction<R_SetExternalPtrTag>();
+          var rSetTag = GetFunction<SET_TAG>();
           var rfCons = GetFunction<Rf_cons>();
           foreach (var arg in args.Reverse())
           {

--- a/R.NET/Internals/Delegates.cs
+++ b/R.NET/Internals/Delegates.cs
@@ -180,7 +180,7 @@ namespace RDotNet.Internals
    internal delegate bool R_has_slot(IntPtr sexp, IntPtr name);
 
    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-   internal delegate IntPtr SET_TAG(IntPtr sexp, IntPtr tag);
+   internal delegate void SET_TAG(IntPtr sexp, IntPtr tag);
 
    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
    internal delegate bool Rf_isEnvironment(IntPtr sexp);

--- a/R.NET/Internals/Delegates.cs
+++ b/R.NET/Internals/Delegates.cs
@@ -180,6 +180,9 @@ namespace RDotNet.Internals
    internal delegate bool R_has_slot(IntPtr sexp, IntPtr name);
 
    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+   internal delegate IntPtr R_SetExternalPtrTag(IntPtr sexp, IntPtr tag);
+
+   [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
    internal delegate bool Rf_isEnvironment(IntPtr sexp);
 
    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/R.NET/Internals/Delegates.cs
+++ b/R.NET/Internals/Delegates.cs
@@ -180,7 +180,7 @@ namespace RDotNet.Internals
    internal delegate bool R_has_slot(IntPtr sexp, IntPtr name);
 
    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-   internal delegate IntPtr R_SetExternalPtrTag(IntPtr sexp, IntPtr tag);
+   internal delegate IntPtr SET_TAG(IntPtr sexp, IntPtr tag);
 
    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
    internal delegate bool Rf_isEnvironment(IntPtr sexp);

--- a/RDotNet.Tests/RFunctionsTest.cs
+++ b/RDotNet.Tests/RFunctionsTest.cs
@@ -205,22 +205,30 @@ setMethod( 'f', 'numeric', function(x, ...) { paste( 'f.numeric called:', printP
          //> f(a='a')
          //[1] "a=a;b=missing_b;cc=null_c;d=d;e=1;f=FALSE;g=123.4"
          checkInvoke(f.InvokeNamed(tc("a", "a")), "a=a;b=missing_b;cc=null_c;d=d;e=1;f=FALSE;g=123.4");
+         checkInvoke(f.InvokeNamedFast(tc("a", "a")), "a=a;b=missing_b;cc=null_c;d=d;e=1;f=FALSE;g=123.4");
          //> f(b='b')
          //[1] "a=missing_a;b=b;cc=null_c;d=d;e=1;f=FALSE;g=123.4"
          checkInvoke(f.InvokeNamed(tc("b", "b")), "a=missing_a;b=b;cc=null_c;d=d;e=1;f=FALSE;g=123.4");
+         checkInvoke(f.InvokeNamedFast(tc("b", "b")), "a=missing_a;b=b;cc=null_c;d=d;e=1;f=FALSE;g=123.4");
          //> f(b='b',cc='cc')
          //[1] "a=missing_a;b=b;cc=cc;d=d;e=1;f=FALSE;g=123.4"
          checkInvoke(f.InvokeNamed(tc("b", "b"), tc("cc", "cc")), "a=missing_a;b=b;cc=cc;d=d;e=1;f=FALSE;g=123.4");
+         checkInvoke(f.InvokeNamedFast(tc("b", "b"), tc("cc", "cc")), "a=missing_a;b=b;cc=cc;d=d;e=1;f=FALSE;g=123.4");
          //> f(cc='cc',b='b')
          //[1] "a=missing_a;b=b;cc=cc;d=d;e=1;f=FALSE;g=123.4"
          checkInvoke(f.InvokeNamed(tc("cc", "cc"), tc("b", "b")), "a=missing_a;b=b;cc=cc;d=d;e=1;f=FALSE;g=123.4");
+         checkInvoke(f.InvokeNamedFast(tc("cc", "cc"), tc("b", "b")), "a=missing_a;b=b;cc=cc;d=d;e=1;f=FALSE;g=123.4");
          //> f(d='ddd')
          //[1] "a=missing_a;b=missing_b;cc=null_c;d=ddd;e=1;f=FALSE;g=123.4"
          checkInvoke(f.InvokeNamed(tc("d", "ddd")), "a=missing_a;b=missing_b;cc=null_c;d=ddd;e=1;f=FALSE;g=123.4");
+         checkInvoke(f.InvokeNamedFast(tc("d", "ddd")), "a=missing_a;b=missing_b;cc=null_c;d=ddd;e=1;f=FALSE;g=123.4");
          //> f(f=TRUE)
          //[1] "a=missing_a;b=missing_b;cc=null_c;d=d;e=1;f=TRUE;g=123.4"
          checkInvoke(f.InvokeNamed(tc("f", "TRUE")), "a=missing_a;b=missing_b;cc=null_c;d=d;e=1;f=TRUE;g=123.4");
-
+         checkInvoke(f.InvokeNamedFast(tc("f", "TRUE")), "a=missing_a;b=missing_b;cc=null_c;d=d;e=1;f=TRUE;g=123.4");
+         //> f(g=456,'a',f=TRUE,'b','cc',e=11)
+         //[1] "a=a;b=b;cc=cc;d=d;e=11;f=TRUE;g=456"
+         checkInvoke(f.InvokeNamedFast(tc("g", 456), tc("", "a"), tc("f", true), tc(null, "b"), tc("", "cc"), tc("e", 11)), "a=a;b=b;cc=cc;d=d;e=11;f=TRUE;g=456");
       }
 
       [Test]


### PR DESCRIPTION
The default implementation of InvokeNamed is inefficient. This PR adds InvokeOptionalFast which is implemented in the same way as Invoke. It also supports partial named and ordered arguments invokation (null or empty strings indicate unnamed arguments) such as `sum(a, na.rm=TRUE, b)`. Here's my benchmark result:
```
InvokeNamed * 10000 finished in 713 ms (result: 110.0)
InvokeNamedFast * 10000 finished in 121 ms (result: 110.0)
```
And the bechmark code (not included in PR):
```F#
    let runMeasure name invoker count =
        let a = engine.CreateNumericVector [| 1.0 .. 10.0 |] :> SymbolicExpression
        let b = engine.CreateNumericVector [| 1.0 .. 10.0 |] :> SymbolicExpression
        let rtrue = engine.Evaluate("TRUE")
        let args = [| null, a; "na.rm", rtrue; null, b |]
        let res: SymbolicExpression = invoker args // skip first run
        let sw = Stopwatch.StartNew()
        for i = 1 to count do
            invoker(args).Dispose()
        let res = res.AsNumeric().[0]
        printfn "%s * %d finished in %d ms (result: %.1f)" name count sw.ElapsedMilliseconds res
    let rsum = engine.Evaluate("sum").AsFunction()
    let count = 10000
    runMeasure "InvokeNamed" (fun a -> rsum.InvokeNamed a) count
    runMeasure "InvokeNamedFast" (fun a -> rsum.InvokeNamedFast a) count
```
I think it'd be better to replace InvokeNamed with InvokeNamedFast since they have the same functionality. The decision is up to you.
