### PR TITLE
Workaround for this == null issue

### DIFF
--- a/R.NET/Devices/CharacterDeviceAdapter.cs
+++ b/R.NET/Devices/CharacterDeviceAdapter.cs
@@ -16,7 +16,7 @@ namespace RDotNet.Devices
         /// from console (this seems to happen on Mono and may be a bug).
         ///
         /// The (somewhat incorrect) workaround is to keep the last device in a static
-		    /// field and use it when 'this == null' (the check is done in 'this.Device').
+        /// field and use it when 'this == null' (the check is done in 'this.Device').
         /// This workarounds: http://rdotnet.codeplex.com/workitem/154
         /// </summary>
         private static ICharacterDevice lastDevice;

--- a/R.NET/Devices/CharacterDeviceAdapter.cs
+++ b/R.NET/Devices/CharacterDeviceAdapter.cs
@@ -1,4 +1,4 @@
-﻿using RDotNet.Internals;
+using RDotNet.Internals;
 using RDotNet.Internals.Unix;
 using RDotNet.NativeLibrary;
 using System;
@@ -10,8 +10,18 @@ namespace RDotNet.Devices
 {
     internal class CharacterDeviceAdapter : IDisposable
     {
-        private readonly ICharacterDevice device;
+        /// <summary>
+        /// When R calls the character device (unamanged R calling managed code),
+        /// it sometimes calls the method with 'this == null' when writing/reading
+        /// from console (this seems to happen on Mono and may be a bug).
+        ///
+        /// The (somewhat incorrect) workaround is to keep the last device in a static
+		    /// field and use it when 'this == null' (the check is done in 'this.Device').
+        /// This workarounds: http://rdotnet.codeplex.com/workitem/154
+        /// </summary>
+        private static ICharacterDevice lastDevice;
 
+        private readonly ICharacterDevice device;
         private REngine engine;
 
         /// <summary>
@@ -24,6 +34,7 @@ namespace RDotNet.Devices
             {
                 throw new ArgumentNullException("device");
             }
+            lastDevice = device;
             this.device = device;
         }
 
@@ -32,7 +43,11 @@ namespace RDotNet.Devices
         /// </summary>
         public ICharacterDevice Device
         {
-            get { return this.device; }
+            get
+            {
+                if (this == null) return lastDevice;
+                else return this.device;
+            }
         }
 
         private REngine Engine


### PR DESCRIPTION
I spent some more time looking into [this R provider issue](http://rdotnet.codeplex.com/workitem/154).

It turns out that the unmanaged code in R sometimes calls the functions in `CharacterDeviceAdapter` with `this == null` (oops!) I'm not sure how exactly is this possible, but it happens very often when using R provider on Mono (R provider specifies custom character device, but that does not seem to be related).

This PR implements a workaround that keeps the last device in a static field and uses that when `this == null` (so it does not change anything when things work correctly). Alternatively, we could just throw away all the messages to be printed when this happens (which would perhaps be less wrong, but you might loose useful output...).

If anybody can figure out what is the root of the issue, that would be great - but having a workaround for this in the meantime would be really good for making R provider useful on Mac!