### PR TITLE
Check if R_Visible handle is valid (fix #17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+.paket/paket.exe

--- a/R.NET/REngine.cs
+++ b/R.NET/REngine.cs
@@ -805,9 +805,15 @@ namespace RDotNet
         private bool GetVisible()
         {
             var symbol = DangerousGetHandle("R_Visible");
-            var value = Marshal.ReadInt32(symbol);
-            var result = Convert.ToBoolean(value);
-            return result;
+            // If the R_Visible symbol is not exported by the current R engine (happens on R-2.14.1), then just return 'true'
+            // https://github.com/BlueMountainCapital/FSharpRProvider/pull/152
+            if (symbol == (System.IntPtr)0) return true;
+            else
+            {
+              var value = Marshal.ReadInt32(symbol);
+              var result = Convert.ToBoolean(value);
+              return result;
+            }
         }
 
         /// <summary>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,4 @@
+* 1.6.4 - Fixed github #17 (do not crash when R_Visible is not exported).
 * 1.6.3 - Fixed github #14 (failing to parse things such as cat('this has # hash');). Known limitation: multi-line R character strings still not parsed correctly. Use Paket for dependency management. Use FAKE. Fix incorrect dependency for R.NET.Fsharp
 * 1.6.2 - Fixed github #14 (failing to parse things such as cat('this has # hash');). Known limitation: multi-line R character strings still not parsed correctly. Use Paket for dependency management. Use FAKE.
 * 1.6.0 - Fix issue where some code commented out was still executed.


### PR DESCRIPTION
I also added `.paket/paket.exe` to the `.gitignore` list so that it is excluded from the repo (this is the standard way of handling this - bootstrapper will download it).

Please ping me when this is on NuGet so that I can update RProvider!