### PR TITLE
Fix parsing of version for '3.2.4 Revised'

### DIFF
--- a/RDotNet.NativeLibrary/NativeUtility.cs
+++ b/RDotNet.NativeLibrary/NativeUtility.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Collections.Generic;
 using System.Collections;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace RDotNet.NativeLibrary
 {
@@ -306,7 +307,11 @@ namespace RDotNet.NativeLibrary
                 if (subKeyNames.Length > 0)
                     version = subKeyNames[0];
             }
-            return new Version(version);
+            // Version should normally be "3.2.4", but some releases had
+            // "3.2.4 Revised" in which case constructor for Version fails.
+            // The regex first extracts the numerical part of the string.
+            var reg = new Regex("([0-9]*\\.)*[0-9]*");
+            return new Version(reg.Match(version).Value);
         }
 
         private static string GetRCurrentVersionStringFromRegistry(RegistryKey rCoreKey)


### PR DESCRIPTION
The R team things that "3.2.4 Revised" is much nicer version number than "3.2.5"... 

![r](https://cloud.githubusercontent.com/assets/485413/14299600/58c29430-fb83-11e5-8e0e-a5ea02e6bbaf.png)
