### PR TITLE
Update getting_started.md

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -85,7 +85,7 @@ entries:
           product: all
           version: all
           print: true
-		  
+
         - title: .NET function callbacks from R
           url: /tut_R_function_callbacks_from_R/
           audience: user, contributor

--- a/pages/overview/getting_started.md
+++ b/pages/overview/getting_started.md
@@ -14,6 +14,8 @@ summary: Getting started with R.NET
 
 There is a page gathering Software Prerequisites listing the platforms on which R.NET is known to run.
 
+Before you can use R.NET, you must first have R on the machine that will be running your code.  The easiest way to acquire the necessary files is to install R from <a href="https://www.r-project.org/">The R Project</a>
+
 As of version 1.5.10 or later, R.NET binaries are platform independent. You might need to set up a small add-on workaround on some Linux distributions (CentOS a known one), but otherwise you can just move and use the same R.NET binaries across platforms.
 
 As of July 2015, NuGet is the strongly recommended way to manage dependencies on R.NET in its binary distribution form. You can find more general information about NuGet at the <a href="http://docs.nuget.org/">NuGet documentation page</a>


### PR DESCRIPTION
Added a link to install R from The R Project.

NOTE 1: The first sentence on this page, "There is a page gathering Software Prerequisites listing the platforms on which R.NET is known to run" is not very helpful because the user does not know where that page is. He/she is likely to go looking for it and, if unsuccessful, this will just result in frustration.  I recommend either linking to the page (preferred, although I don't know where it is) or removing this sentence completely.
NOTE 2: I am a new user for both R and R.NET.  I believe the line I added is both true and helpful.  I don't usually contribute to open source projects, so if this was done incorrectly, please let me know what I should have done differently.